### PR TITLE
Preliminary checks for train and val lmdb

### DIFF
--- a/run.py
+++ b/run.py
@@ -55,8 +55,6 @@ demandpath(SPEARMINT_ROOT + '/spearmint/cleanup.sh', 'Spearmint cleanup script w
 demandpath(MONGODB_BIN, 'MongoDB is not installed? Server binary not found at %s.')
 
 warningpath(args.experiment + '/data/mean_train.binaryproto', 'WARNING: image mean file was not found: %s. Ignore this message if you know that you do not need it.')
-demandpath(args.experiment + '/data/train_lmdb', 'Please put your training LMDB as %s.')
-demandpath(args.experiment + '/data/val_lmdb', 'Please put your validation LMDB as %s.')
 demandpath(args.experiment + '/model/solver.prototxt', 'Your Caffe solver file should be located at %s.')
 demandpath(args.experiment + '/model/trainval.prototxt', 'Your Caffe network description file should be located at %s.')
 


### PR DESCRIPTION
Training and validation LMDB folders ('/data/train_lmdb' and '/data/val_lmdb') should not be forced
to the user in the preliminary checks, for they're used neither in spearmint nor in run.py. In addition, Caffe can be called on other file formats (such as hdf5) or other databases outside the spearmint's experiment.
